### PR TITLE
account management page

### DIFF
--- a/Mailgun_Subscriptions/API.php
+++ b/Mailgun_Subscriptions/API.php
@@ -7,7 +7,7 @@ namespace Mailgun_Subscriptions;
 class API {
 	private $key = '';
 	private $url = '';
-	public function __construct( $apiKey, $apiEndpoint = "api.mailgun.net", $apiVersion = "v2", $ssl = true ) {
+	public function __construct( $apiKey, $apiEndpoint = "api.mailgun.net", $apiVersion = "v3", $ssl = true ) {
 		$this->key = $apiKey;
 		$this->url = $this->build_base_url( $apiEndpoint, $apiVersion, $ssl );
 	}
@@ -35,6 +35,40 @@ class API {
 			array(
 				'body' => $args,
 				'headers' => $this->get_request_headers(),
+			)
+		);
+		if ( is_wp_error($response) ) {
+			return FALSE;
+		}
+		$response['body'] = json_decode($response['body']);
+		return $response;
+	}
+
+	public function put( $endpoint, $args = array() ) {
+		$url = $this->url . $endpoint;
+		$response = wp_remote_request(
+			$url,
+			array(
+				'body' => $args,
+				'headers' => $this->get_request_headers(),
+				'method' => 'PUT',
+			)
+		);
+		if ( is_wp_error($response) ) {
+			return FALSE;
+		}
+		$response['body'] = json_decode($response['body']);
+		return $response;
+	}
+
+	public function delete( $endpoint, $args = array() ) {
+		$url = $this->url . $endpoint;
+		$response = wp_remote_request(
+			$url,
+			array(
+				'body' => $args,
+				'headers' => $this->get_request_headers(),
+				'method' => 'DELETE',
 			)
 		);
 		if ( is_wp_error($response) ) {

--- a/Mailgun_Subscriptions/Account_Management_Hash.php
+++ b/Mailgun_Subscriptions/Account_Management_Hash.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+
+class Account_Management_Hash {
+	private $email_address = '';
+
+	public function __construct( $email_address ) {
+		$this->email_address = $email_address;
+	}
+
+	public function get_hash() {
+		return wp_hash( $this->email_address, 'auth' );
+	}
+}

--- a/Mailgun_Subscriptions/Account_Management_Hash.php
+++ b/Mailgun_Subscriptions/Account_Management_Hash.php
@@ -3,7 +3,11 @@
 
 namespace Mailgun_Subscriptions;
 
-
+/**
+ * Class Account_Management_Hash
+ *
+ * Builds the hash to validate a user's account management request
+ */
 class Account_Management_Hash {
 	private $email_address = '';
 

--- a/Mailgun_Subscriptions/Account_Management_Page.php
+++ b/Mailgun_Subscriptions/Account_Management_Page.php
@@ -1,0 +1,318 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+
+class Account_Management_Page {
+	const SHORTCODE = 'mailgun_account_management';
+	const ACTION_REQUEST_TOKEN = 'request-token';
+	const EMAIL_ADDRESS_FIELD = 'mailgun_account_management_email_address';
+	private $page_id = 0;
+	/** @var Account_Management_Page_Authenticator */
+	private $authenticator = null;
+
+	public function __construct( $authenticator ) {
+		$this->authenticator = $authenticator;
+	}
+
+	public function init() {
+		$this->page_id = $this->get_page_id_option();
+		if ( ! $this->page_id && current_user_can( 'edit_pages' ) ) {
+			$this->create_default_page();
+		}
+		add_action( 'template_redirect', array( $this, 'setup_authentication_cookie' ), 10, 0 );
+
+		add_action( 'trashed_post', array( $this, 'listen_for_page_deletion' ) );
+		add_action( 'deleted_post', array( $this, 'listen_for_page_deletion' ) );
+
+		add_action( 'the_post', array( $this, 'setup_postdata' ) );
+	}
+
+	public function get_page_url() {
+		$id = $this->get_page_id_option();
+		$url = get_permalink( $id );
+		return $url;
+	}
+
+	private function get_page_id_option() {
+		return (int)get_option( Admin_Page::OPTION_ACCOUNT_PAGE, 0 );
+	}
+
+	public function create_default_page() {
+		$this->page_id = wp_insert_post( array(
+			'post_type' => 'page',
+			'post_title' => __( 'Subscription Management', 'mailgun-subscriptions' ),
+			'post_status' => 'publish',
+		));
+		update_option( Admin_Page::OPTION_ACCOUNT_PAGE, $this->page_id );
+	}
+
+	public function setup_authentication_cookie() {
+		if ( get_queried_object_id() != $this->get_page_id_option() ) {
+			return;
+		}
+		if ( isset( $_GET[ Account_Management_Page_Authenticator::EMAIL_ARG ] ) && isset( $_GET[ Account_Management_Page_Authenticator::HASH_ARG ] ) ) {
+			$expiration = time() + apply_filters( 'mailgun_subscriptions_auth_cookie_expiration', 14 * DAY_IN_SECONDS );
+			$cookie_value = array(
+				Account_Management_Page_Authenticator::EMAIL_ARG => $_GET[ Account_Management_Page_Authenticator::EMAIL_ARG ],
+				Account_Management_Page_Authenticator::HASH_ARG => $_GET[ Account_Management_Page_Authenticator::HASH_ARG ]
+			);
+			$cookie_value = json_encode( $cookie_value );
+			setcookie(
+				Account_Management_Page_Authenticator::COOKIE_NAME,
+				$cookie_value,
+				$expiration,
+				COOKIEPATH,
+				COOKIE_DOMAIN,
+				false,
+				true
+			);
+			wp_safe_redirect( $this->get_page_url() );
+			exit();
+		}
+	}
+
+	public function listen_for_page_deletion( $post_id ) {
+		if ( $post_id == $this->page_id ) {
+			$this->page_id = 0;
+			update_option( Admin_Page::OPTION_ACCOUNT_PAGE, 0 );
+		}
+	}
+
+	/**
+	 * Spoof the global $post to hold just a shortcode for the account management page
+	 *
+	 * @param \WP_Post $post A reference to the global post object
+	 * @return void
+	 */
+	public function setup_postdata( $post ) {
+		if ( $post->ID != $this->page_id ) {
+			return;
+		}
+
+		$GLOBALS['pages'] = array( sprintf( '[%s]', self::SHORTCODE ) );
+		$GLOBALS['numpages'] = 1;
+		$GLOBALS['multipage'] = 0;
+	}
+
+	public function get_page_contents() {
+		switch ( $this->authenticator->validate() ) {
+			case Account_Management_Page_Authenticator::VALID:
+				$content = $this->get_account_page_content( $this->authenticator->get_email() );
+				break;
+			case Account_Management_Page_Authenticator::INVALID_HASH:
+				$content = $this->get_invalid_hash_content();
+				break;
+			case Account_Management_Page_Authenticator::NO_USER:
+			default:
+				$content = $this->get_empty_page_content();
+				break;
+		}
+		return $content;
+	}
+
+	private function get_message_codes() {
+		$messages = isset( $_GET[ 'mailgun-account-message' ] ) ? $_GET[ 'mailgun-account-message' ] : array();
+		if ( isset( $_GET[ 'mailgun-message' ] ) && $_GET[ 'mailgun-message' ] == 'submitted' ) {
+			// special case when subscribing to a new list
+			$messages[] = 'submitted';
+		}
+		return $messages;
+	}
+
+	private function get_account_page_content( $email_address ) {
+		$lists = $this->get_subscribed_lists( $email_address );
+		$base_url = $this->get_page_url();
+		ob_start();
+		echo '<div class="mailgun-subscription-account-management">';
+
+		$messages = $this->get_message_codes();
+		if ( !empty( $messages ) ) {
+			$this->show_form_messages( $messages );
+		}
+
+		echo '<p>';
+		printf( __( 'Email Address: <strong>%s</strong>', 'mailgun-subscriptions' ), esc_html( $email_address ) );
+		echo '</p>';
+		foreach ( $lists as $list_address => $list ) {
+			$subscribe_url = add_query_arg( array(
+				'mailgun-action' => 'account-subscribe',
+				'list' => $list_address,
+				'nonce' => wp_create_nonce( 'account-subscribe' ),
+			), $base_url );
+			$unsubscribe_url = add_query_arg( array(
+				'mailgun-action' => 'account-unsubscribe',
+				'list' => $list_address,
+				'nonce' => wp_create_nonce( 'account-unsubscribe' ),
+			), $base_url );
+			$resubscribe_url = add_query_arg( array(
+				'mailgun-action' => 'account-resubscribe',
+				'list' => $list_address,
+				'nonce' => wp_create_nonce( 'account-resubscribe' ),
+			), $base_url );
+			echo '<div class="mailgun-subscription-details">';
+			echo '<h3>', esc_html( $list[ 'name' ] ), '</h3>';
+			if ( $list[ 'member' ] ) {
+				if ( ! $list[ 'subscribed' ] ) {
+					echo $this->unsubscribed_list( $resubscribe_url );
+				} elseif ( $list[ 'suppressions' ][ 'unsubscribes' ] ) {
+					echo $this->unsubscribed_domain_list( $resubscribe_url );
+				} elseif ( $list[ 'suppressions' ][ 'bounces' ] ) {
+					echo $this->bounced_list( $resubscribe_url );
+				} elseif ( $list[ 'suppressions' ][ 'complaints' ] ) {
+					echo $this->spammed_list( $resubscribe_url );
+				} else {
+					echo $this->subscribed_list( $unsubscribe_url );
+				}
+			} else {
+				echo $this->not_subscribed_list( $subscribe_url );
+			}
+			echo '</div>';
+		}
+		echo '</div>';
+		return ob_get_clean();
+	}
+
+	private function subscribed_list( $unsubscribe_url ) {
+		return sprintf(
+			'<p class="subscribe current-status">%s</p><p class="unsubscribe"><a href="%s">%s</a></p>',
+			__( 'Subscribed', 'mailgun-subscriptions' ),
+			esc_url( $unsubscribe_url ),
+			__( 'Unsubscribe »', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function not_subscribed_list( $subscribe_url ) {
+		return sprintf(
+			'<p class="subscribe"><a href="%s">%s</a></p><p class="not-subscribed unsubscribe current-status">%s</p>',
+			esc_url( $subscribe_url ),
+			__( 'Subscribe »', 'mailgun-subscriptions' ),
+			__( 'Not subscribed', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function unsubscribed_list( $resubscribe_url ) {
+		return sprintf(
+			'<p class="subscribe"><a href="%s">%s</a></p><p class="unsubscribe current-status">%s</p>',
+			esc_url( $resubscribe_url ),
+			__( 'Subscribe »', 'mailgun-subscriptions' ),
+			__( 'Unsubscribed', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function unsubscribed_domain_list( $resubscribe_url ) {
+		return sprintf(
+			'<p class="subscribe"><a href="%s">%s</a></p><p class="unsubscribe current-status">%s</p>',
+			esc_url( $resubscribe_url ),
+			__( 'Subscribe »', 'mailgun-subscriptions' ),
+			__( 'Unsubscribed <span class="description">(you have requested to unsubscribe from all emails from this domain)</span>', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function spammed_list( $resubscribe_url ) {
+		return sprintf(
+			'<p class="subscribe"><a href="%s">%s</a></p><p class="unsubscribe current-status">%s</p>',
+			esc_url( $resubscribe_url ),
+			__( 'Subscribe »', 'mailgun-subscriptions' ),
+			__( 'Unsubscribed <span class="description">(you reported this list as spam)</span>', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function bounced_list( $resubscribe_url ) {
+		return sprintf(
+			'<p class="subscribe"><a href="%s">%s</a></p><p class="unsubscribe current-status">%s</p>',
+			esc_url( $resubscribe_url ),
+			__( 'Subscribe »', 'mailgun-subscriptions' ),
+			__( 'Unsubscribed <span class="description">(your email address bounced)</span>', 'mailgun-subscriptions' )
+		);
+	}
+
+	private function get_subscribed_lists( $email_address ) {
+		$api = Plugin::instance()->api();
+		$lists = Plugin::instance()->get_lists( 'name' );
+		$lists = wp_list_filter( $lists, array( 'hidden' => true ), 'NOT' );
+		foreach ( $lists as $list_address => &$list ) {
+			$list[ 'member' ] = false;
+			$list[ 'suppressions' ] = array();
+			$path = sprintf( 'lists/%s/members/%s', $list_address, $email_address );
+			$response = $api->get( $path );
+			if ( wp_remote_retrieve_response_code( $response ) == 200 ) {
+				$body = wp_remote_retrieve_body( $response );
+				$list[ 'member' ] = true;
+				$list[ 'subscribed' ] = !empty( $body->member->subscribed );
+				$list[ 'suppressions' ] = $this->get_suppressions( $email_address, $list_address );
+			}
+		}
+		return $lists;
+	}
+
+	private function get_suppressions( $email_address, $list_address ) {
+		$suppressions = Suppressions::instance( $email_address );
+		return array(
+			Suppressions::BOUNCES => $suppressions->has_bounces( $list_address ),
+			Suppressions::COMPLAINTS => $suppressions->has_complaints( $list_address ),
+			Suppressions::UNSUBSCRIBES => $suppressions->has_unsubscribes( $list_address ),
+		);
+	}
+
+	private function get_invalid_hash_content() {
+		$email = $this->authenticator->get_email();
+		$errors = array( 'invalid-hash' );
+		return $this->get_request_email_form( $email, $errors );
+	}
+
+	private function get_empty_page_content() {
+		$messages = $this->get_message_codes();
+		return $this->get_request_email_form( '', $messages );
+	}
+
+	private function get_request_email_form( $default_address = '', $errors = array() ) {
+		ob_start();
+
+		if ( !empty( $errors ) ) {
+			$this->show_form_messages( $errors );
+		}
+		?>
+		<form action="" method="post">
+			<?php wp_nonce_field( self::ACTION_REQUEST_TOKEN ); ?>
+			<input type="hidden" value="<?php echo self::ACTION_REQUEST_TOKEN; ?>" name="mailgun-action" />
+			<p><?php _e( "Fill in your email address below and we'll send you a link to log in and manage your account.", 'mailgun-subscriptions' ); ?></p>
+			<p><input type="text" value="<?php echo esc_attr( $default_address ); ?>" name="<?php echo self::EMAIL_ADDRESS_FIELD; ?>" placeholder="<?php esc_attr_e( 'e-mail address', 'mailgun-subscriptions' ); ?>" /></p>
+			<p><input type="submit" value="<?php esc_attr_e( 'Send e-mail', 'mailgun-subscriptions' ); ?>" /></p>
+		</form>
+		<?php
+		return ob_get_clean();
+	}
+
+	protected function show_form_messages( $message ) {
+		if ( !is_array($message) ) {
+			$message = array($message);
+		}
+		foreach ( $message as $code ) {
+			echo '<p class="mailgun-message">', $this->get_message_string($code), '</p>';
+		}
+	}
+
+	protected function get_message_string( $code ) {
+		switch ( $code ) {
+			case 'submitted':
+				return __('Please check your email for a link to confirm your subscription.', 'mailgun-subscriptions');
+			case 'subscription-updated':
+				return __( 'Subscription updated.', 'mailgun-subscriptions' );
+			case 'request-submitted':
+				return __( 'Request submitted. Your email should be arriving shortly.', 'mailgun-subscriptions' );
+			case 'no-email':
+				return __( 'Please verify that you have entered your email address correctly.', 'mailgun-subscriptions' );
+			case 'invalid-nonce':
+				return __( 'We were unable to validate your request. Please try submitting the form again.', 'mailgun-subscriptions' );
+			case 'invalid-hash':
+				return __( 'Your login URL has expired. Please request a new one.', 'mailgun-subscriptions' );
+			default:
+				$message = '';
+				break;
+		}
+		$message = apply_filters( 'mailgun_message', $message, $code, 'widget' );
+		return $message;
+	}
+}

--- a/Mailgun_Subscriptions/Account_Management_Page.php
+++ b/Mailgun_Subscriptions/Account_Management_Page.php
@@ -335,6 +335,8 @@ class Account_Management_Page {
 				return __( 'Please verify that you have entered your email address correctly.', 'mailgun-subscriptions' );
 			case 'invalid-nonce':
 				return __( 'We were unable to validate your request. Please try submitting the form again.', 'mailgun-subscriptions' );
+			case 'invalid-email':
+				return __( 'We did not understand your email address. Please try submitting the form again.', 'mailgun-subscriptions' );
 			case 'invalid-hash':
 				return __( 'Your login URL has expired. Please request a new one.', 'mailgun-subscriptions' );
 			default:

--- a/Mailgun_Subscriptions/Account_Management_Page.php
+++ b/Mailgun_Subscriptions/Account_Management_Page.php
@@ -3,7 +3,11 @@
 
 namespace Mailgun_Subscriptions;
 
-
+/**
+ * Class Account_Management_Page
+ *
+ * Sets up and displays the account management page
+ */
 class Account_Management_Page {
 	const SHORTCODE = 'mailgun_account_management';
 	const ACTION_REQUEST_TOKEN = 'request-token';
@@ -39,6 +43,11 @@ class Account_Management_Page {
 		return (int)get_option( Admin_Page::OPTION_ACCOUNT_PAGE, 0 );
 	}
 
+	/**
+	 * Automatically creates the subscription management page
+	 *
+	 * @return void
+	 */
 	public function create_default_page() {
 		$this->page_id = wp_insert_post( array(
 			'post_type' => 'page',

--- a/Mailgun_Subscriptions/Account_Management_Page.php
+++ b/Mailgun_Subscriptions/Account_Management_Page.php
@@ -25,6 +25,7 @@ class Account_Management_Page {
 		if ( ! $this->page_id && current_user_can( 'edit_pages' ) ) {
 			$this->create_default_page();
 		}
+		add_action( 'template_redirect', array( $this, 'disable_caching' ), 0, 0 );
 		add_action( 'template_redirect', array( $this, 'setup_authentication_cookie' ), 10, 0 );
 
 		add_action( 'trashed_post', array( $this, 'listen_for_page_deletion' ) );
@@ -55,6 +56,25 @@ class Account_Management_Page {
 			'post_status' => 'publish',
 		));
 		update_option( Admin_Page::OPTION_ACCOUNT_PAGE, $this->page_id );
+	}
+
+	public function disable_caching() {
+		if ( get_queried_object_id() == $this->get_page_id_option() ) {
+			$this->do_not_cache();
+		}
+	}
+
+	/**
+	 * Set headers to try to disable page caching for the current request
+	 */
+	public function do_not_cache() {
+		nocache_headers(); // reverse proxies, browsers
+		if ( !defined('DONOTCACHEPAGE') ) {
+			define('DONOTCACHEPAGE', TRUE); // W3TC, supercache
+		}
+		if ( function_exists('batcache_cancel') ) {
+			batcache_cancel(); // batcache
+		}
 	}
 
 	public function setup_authentication_cookie() {

--- a/Mailgun_Subscriptions/Account_Management_Page_Authenticator.php
+++ b/Mailgun_Subscriptions/Account_Management_Page_Authenticator.php
@@ -1,0 +1,65 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+
+class Account_Management_Page_Authenticator {
+	const VALID        = 0;
+	const NO_USER      = 1;
+	const INVALID_HASH = 2;
+
+	const EMAIL_ARG = 'email';
+	const HASH_ARG  = 'hash';
+	const COOKIE_NAME = 'mailgun-account';
+
+	private $validation_result;
+
+	private $email_address = '';
+	private $hash          = '';
+
+	public function __construct( $submission ) {
+		if ( isset( $submission[ self::COOKIE_NAME ] ) ) {
+			$submission = json_decode( stripslashes( $submission[ self::COOKIE_NAME ] ), true );
+		} else {
+			$submission = array();
+		}
+		if ( !empty( $submission[ self::EMAIL_ARG ] ) ) {
+			$this->email_address = $submission[ self::EMAIL_ARG ];
+		}
+		if ( !empty( $submission[ self::HASH_ARG ] ) ) {
+			$this->hash = $submission[ self::HASH_ARG ];
+		}
+	}
+
+	public function get_email() {
+		return $this->email_address;
+	}
+
+	public function get_hash() {
+		return $this->hash;
+	}
+
+	public function validate() {
+		if ( isset( $this->validation_result ) ) {
+			return $this->validation_result;
+		}
+		$this->validation_result = $this->do_validation();
+		return $this->validation_result;
+	}
+
+	private function do_validation() {
+		if ( empty( $this->email_address ) ) {
+			return self::NO_USER;
+		}
+		if ( ! $this->validate_hash() ) {
+			return self::INVALID_HASH;
+		}
+		return self::VALID;
+	}
+
+	private function validate_hash() {
+		$hash = new Account_Management_Hash( $this->email_address );
+		return $hash->get_hash() == $this->hash;
+	}
+}

--- a/Mailgun_Subscriptions/Account_Management_Page_Authenticator.php
+++ b/Mailgun_Subscriptions/Account_Management_Page_Authenticator.php
@@ -3,7 +3,11 @@
 
 namespace Mailgun_Subscriptions;
 
-
+/**
+ * Class Account_Management_Page_Authenticator
+ *
+ * Authenticates access to the account management page
+ */
 class Account_Management_Page_Authenticator {
 	const VALID        = 0;
 	const NO_USER      = 1;

--- a/Mailgun_Subscriptions/Account_Management_Subscription_Request_Handler.php
+++ b/Mailgun_Subscriptions/Account_Management_Subscription_Request_Handler.php
@@ -1,0 +1,100 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+class Account_Management_Subscription_Request_Handler {
+	private $submission = array();
+	/** @var Account_Management_Page_Authenticator */
+	private $authenticator = null;
+	private $success = '';
+	private $error = '';
+	private $action = '';
+
+	public function __construct( $submission, $authenticator ) {
+		$this->submission = $submission;
+		$this->authenticator = $authenticator;
+		if ( !isset( $this->submission[ 'mailgun-action' ] ) ) {
+			throw new \InvalidArgumentException( __( 'No action provided', 'mailgun-subscriptions' ) );
+		}
+		$this->action = $this->submission[ 'mailgun-action' ];
+	}
+	
+	public function handle_request() {
+		if ( $this->is_valid_submission() ) {
+			switch ( $this->action ) {
+				case 'account-subscribe':
+					$this->handle_subscribe_request( $this->authenticator->get_email(), $this->submission[ 'list' ] );
+					break;
+				case 'account-unsubscribe':
+					$this->handle_unsubscribe_request( $this->authenticator->get_email(), $this->submission[ 'list' ] );
+					break;
+				case 'account-resubscribe':
+					$this->handle_resubscribe_request( $this->authenticator->get_email(), $this->submission[ 'list' ] );
+					break;
+			}
+			$this->do_success_redirect();
+		} else {
+			$this->do_error_redirect();
+		}
+	}
+
+	private function handle_subscribe_request( $email_address, $list_address ) {
+		$submission_handler = new Submission_Handler( array(
+			'mailgun-lists' => array( $list_address ),
+			'mailgun-subscriber-email' => $email_address,
+		));
+		$submission_handler->handle_request();
+	}
+
+	private function handle_unsubscribe_request( $email_address, $list_address ) {
+		$api = Plugin::instance()->api();
+		$path = sprintf( 'lists/%s/members/%s', $list_address, $email_address );
+		$api->put( $path, array( 'subscribed' => 'no' ) );
+	}
+
+	private function handle_resubscribe_request( $email_address, $list_address ) {
+		$suppressions = Suppressions::instance( $email_address );
+		$suppressions->clear_all( $list_address );
+
+		$api = Plugin::instance()->api();
+		$path = sprintf( 'lists/%s/members/%s', $list_address, $email_address );
+		$api->put( $path, array( 'subscribed' => 'yes' ) );
+	}
+
+	protected function is_valid_submission() {
+		if ( !isset( $this->submission[ 'nonce' ] ) || !wp_verify_nonce( $this->submission[ 'nonce' ], $this->action ) ) {
+			$this->error = 'invalid-nonce';
+		} elseif( $this->authenticator->validate() !== Account_Management_Page_Authenticator::VALID || !isset( $this->submission[ 'list' ] ) ) {
+			$this->error = 'invalid-request';
+		}
+		return empty($this->error);
+	}
+
+	protected function do_success_redirect() {
+		$url = $this->get_redirect_base_url();
+		$url = add_query_arg( array(
+			'mailgun-account-message' => 'subscription-updated',
+		), $url );
+		wp_safe_redirect($url);
+		exit();
+	}
+
+	protected function do_error_redirect() {
+		$url = $this->get_redirect_base_url();
+		$url = add_query_arg( array(
+			'mailgun-account-message' => $this->error,
+		), $url );
+		wp_safe_redirect($url);
+		exit();
+	}
+
+	protected function get_redirect_base_url() {
+		$url = Plugin::instance()->account_management_page()->get_page_url();
+		foreach ( array('mailgun-action', 'list', 'nonce') as $key ) {
+			$url = remove_query_arg( $key, $url);
+		}
+		return $url;
+	}
+
+}

--- a/Mailgun_Subscriptions/Account_Management_Subscription_Request_Handler.php
+++ b/Mailgun_Subscriptions/Account_Management_Subscription_Request_Handler.php
@@ -7,7 +7,6 @@ class Account_Management_Subscription_Request_Handler {
 	private $submission = array();
 	/** @var Account_Management_Page_Authenticator */
 	private $authenticator = null;
-	private $success = '';
 	private $error = '';
 	private $action = '';
 

--- a/Mailgun_Subscriptions/Account_Management_Token_Email.php
+++ b/Mailgun_Subscriptions/Account_Management_Token_Email.php
@@ -3,6 +3,11 @@
 
 namespace Mailgun_Subscriptions;
 
+/**
+ * Class Account_Management_Token_Email
+ *
+ * Sends an email to the user with a link to manage their account.
+ */
 class Account_Management_Token_Email {
 	private $email_address = '';
 	
@@ -14,7 +19,7 @@ class Account_Management_Token_Email {
 		return wp_mail( $this->email_address, $this->get_subject(), $this->get_body() );
 	}
 
-	private function get_token_link() {
+	public function get_token_link() {
 		$hasher = new Account_Management_Hash( $this->email_address );
 		$hash = $hasher->get_hash();
 		$base_url = Plugin::instance()->account_management_page()->get_page_url();
@@ -26,12 +31,17 @@ class Account_Management_Token_Email {
 	}
 
 	private function get_subject() {
-		return 'Account Management'; // TODO: customizable
+		return apply_filters( 'mailgun_token_email_subject', sprintf( __( '[%s] Manage Your Subscriptions', 'mailgun-subscriptions' ), get_bloginfo('name') ) );
 	}
 
 	private function get_body() {
-		$link = $this->get_token_link();
-		$link = sprintf( '<a href="%s">%s</a>', esc_url_raw( $link ), esc_url( $link ) );
-		return $link; // TODO: customizable
+		$message = $this->get_token_message_template();
+		$message = str_replace( '[link]', esc_url_raw( $this->get_token_link() ), $message );
+		return $message;
+	}
+
+	protected function get_token_message_template() {
+		$template = get_option( 'mailgun_token_email_template', Template::token_email() );
+		return apply_filters( 'mailgun_token_email_template', $template );
 	}
 }

--- a/Mailgun_Subscriptions/Account_Management_Token_Email.php
+++ b/Mailgun_Subscriptions/Account_Management_Token_Email.php
@@ -24,8 +24,8 @@ class Account_Management_Token_Email {
 		$hash = $hasher->get_hash();
 		$base_url = Plugin::instance()->account_management_page()->get_page_url();
 		$url = add_query_arg( array(
-			Account_Management_Page_Authenticator::EMAIL_ARG => $this->email_address,
-			Account_Management_Page_Authenticator::HASH_ARG => $hash,
+			Account_Management_Page_Authenticator::EMAIL_ARG => urlencode( $this->email_address ),
+			Account_Management_Page_Authenticator::HASH_ARG => urlencode( $hash ),
 		), $base_url );
 		return $url;
 	}

--- a/Mailgun_Subscriptions/Account_Management_Token_Email.php
+++ b/Mailgun_Subscriptions/Account_Management_Token_Email.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+class Account_Management_Token_Email {
+	private $email_address = '';
+	
+	public function __construct( $email_address ) {
+		$this->email_address = $email_address;
+	}
+
+	public function send() {
+		return wp_mail( $this->email_address, $this->get_subject(), $this->get_body() );
+	}
+
+	private function get_token_link() {
+		$hasher = new Account_Management_Hash( $this->email_address );
+		$hash = $hasher->get_hash();
+		$base_url = Plugin::instance()->account_management_page()->get_page_url();
+		$url = add_query_arg( array(
+			Account_Management_Page_Authenticator::EMAIL_ARG => $this->email_address,
+			Account_Management_Page_Authenticator::HASH_ARG => $hash,
+		), $base_url );
+		return $url;
+	}
+
+	private function get_subject() {
+		return 'Account Management'; // TODO: customizable
+	}
+
+	private function get_body() {
+		$link = $this->get_token_link();
+		$link = sprintf( '<a href="%s">%s</a>', esc_url_raw( $link ), esc_url( $link ) );
+		return $link; // TODO: customizable
+	}
+}

--- a/Mailgun_Subscriptions/Account_Management_Token_Request_Handler.php
+++ b/Mailgun_Subscriptions/Account_Management_Token_Request_Handler.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+class Account_Management_Token_Request_Handler {
+	private $submission = array();
+	private $error = '';
+
+	public function __construct( $submission ) {
+		$this->submission = $submission;
+	}
+	
+	public function handle_request() {
+		if ( $this->is_valid_submission() ) {
+			$this->send_token_email( $this->submission[ Account_Management_Page::EMAIL_ADDRESS_FIELD ] );
+			$this->do_success_redirect();
+		} else {
+			$this->do_error_redirect();
+		}
+	}
+
+	protected function send_token_email( $email_address ) {
+		$email_builder = new Account_Management_Token_Email( $email_address );
+		$email_builder->send();
+	}
+
+	protected function is_valid_submission() {
+		if ( empty( $this->submission[ Account_Management_Page::EMAIL_ADDRESS_FIELD ] ) ) {
+			$this->error = 'no-email';
+		} elseif ( empty( $this->submission[ '_wp_nonce'] ) || ! wp_verify_nonce( $this->submission[ '_wp_nonce'], Account_Management_Page::ACTION_REQUEST_TOKEN ) ) {
+			$this->error = 'invalid-nonce';
+		}
+		return empty($this->errors);
+	}
+
+	protected function do_success_redirect() {
+		$url = $this->get_redirect_base_url();
+		$url = add_query_arg( array(
+			'mailgun-account-message' => 'request-submitted',
+		), $url );
+		wp_safe_redirect($url);
+		exit();
+	}
+
+	protected function do_error_redirect() {
+		$url = $this->get_redirect_base_url();
+		$url = add_query_arg( array(
+			'mailgun-account-message' => $this->error,
+		), $url );
+		wp_safe_redirect($url);
+		exit();
+	}
+
+	protected function get_redirect_base_url() {
+		$url = Plugin::instance()->account_management_page()->get_page_url();
+		foreach ( array('mailgun-account-message', 'mailgun-error', 'mailgun-action', 'ref') as $key ) {
+			$url = remove_query_arg( $key, $url);
+		}
+		return $url;
+	}
+
+}

--- a/Mailgun_Subscriptions/Account_Management_Token_Request_Handler.php
+++ b/Mailgun_Subscriptions/Account_Management_Token_Request_Handler.php
@@ -28,10 +28,22 @@ class Account_Management_Token_Request_Handler {
 	protected function is_valid_submission() {
 		if ( empty( $this->submission[ Account_Management_Page::EMAIL_ADDRESS_FIELD ] ) ) {
 			$this->error = 'no-email';
-		} elseif ( empty( $this->submission[ '_wp_nonce'] ) || ! wp_verify_nonce( $this->submission[ '_wp_nonce'], Account_Management_Page::ACTION_REQUEST_TOKEN ) ) {
-			$this->error = 'invalid-nonce';
+			return false;
 		}
-		return empty($this->errors);
+		if ( empty( $this->submission[ '_wpnonce'] ) || ! wp_verify_nonce( $this->submission[ '_wpnonce'], Account_Management_Page::ACTION_REQUEST_TOKEN ) ) {
+			$this->error = 'invalid-nonce';
+			return false;
+		}
+		if ( ! $this->is_valid_email( $this->submission[ Account_Management_Page::EMAIL_ADDRESS_FIELD ] ) ) {
+			$this->error = 'invalid-email';
+			return false;
+		}
+		return true;
+	}
+
+	private function is_valid_email( $email_address ) {
+		$api = Plugin::instance()->api( true );
+		return (bool) ( $api->validate_email( $email_address ) );
 	}
 
 	protected function do_success_redirect() {

--- a/Mailgun_Subscriptions/Admin_Page.php
+++ b/Mailgun_Subscriptions/Admin_Page.php
@@ -150,6 +150,24 @@ class Admin_Page {
 			'mailgun_welcome_email_template'
 		);
 
+		add_settings_field(
+			'mailgun_token_email_template',
+			__('Account Management Email', 'mailgun-subscriptions'),
+			array( $this, 'display_textarea_field' ),
+			self::MENU_SLUG,
+			'confirmation',
+			array(
+				'option' => 'mailgun_token_email_template',
+				'description' => $this->get_token_email_field_description(),
+				'default' => Template::token_email(),
+			)
+		);
+
+		register_setting(
+			self::MENU_SLUG,
+			'mailgun_token_email_template'
+		);
+
 		register_setting(
 			self::MENU_SLUG,
 			'mailgun_lists'
@@ -395,7 +413,14 @@ class Admin_Page {
 	public function get_welcome_email_field_description() {
 		$description = __("This email will be sent to users after they confirm their subscription. Leave blank to disable this email. Your template can contain the following shortcodes:<br />
 			<code>[email]</code> &ndash; This is the user's email address.<br />
-			<code>[lists]</code> &ndash; This is a list of the lists the user opted to subscribe to.", 'mailgun-subscriptions' );
+			<code>[lists]</code> &ndash; This is a list of the lists the user opted to subscribe to.<br />
+			<code>[link]</code> &ndash; This is the URL to the user's account management page.", 'mailgun-subscriptions' );
+		return $description;
+	}
+
+	public function get_token_email_field_description() {
+		$description = __("This email will be sent to users when they request a link to their account management page. Your template can contain the following shortcodes:<br />
+			<code>[link]</code> &ndash; This is the URL to the user's account management page.", 'mailgun-subscriptions' );
 		return $description;
 	}
 

--- a/Mailgun_Subscriptions/Admin_Page.php
+++ b/Mailgun_Subscriptions/Admin_Page.php
@@ -7,6 +7,7 @@ namespace Mailgun_Subscriptions;
  */
 class Admin_Page {
 	const MENU_SLUG = 'mailgun_subscriptions';
+	const OPTION_ACCOUNT_PAGE = 'mailgun_account_management_page';
 
 	public function refresh_caches() {
 		$lists = $this->get_mailing_lists_from_api();
@@ -159,6 +160,26 @@ class Admin_Page {
 			'mailgun_new_list',
 			array( $this, 'save_new_list' )
 		);
+
+		add_settings_section(
+			'account_management',
+			__('Account Management', 'mailgun-subscriptions'),
+			'__return_false',
+			self::MENU_SLUG
+		);
+
+		add_settings_field(
+			self::OPTION_ACCOUNT_PAGE,
+			__('Account Management Page', 'mailgun-subscriptions'),
+			array( $this, 'display_page_select_field' ),
+			self::MENU_SLUG,
+			'account_management',
+			array(
+				'option' => self::OPTION_ACCOUNT_PAGE,
+				'description' => $this->get_account_management_page_description(),
+				'default' => 0,
+			)
+		);
 	}
 
 	public function display() {
@@ -198,6 +219,22 @@ class Admin_Page {
 		$args = wp_parse_args( $args, array('default' => '', 'description' => '', 'rows' => 5, 'cols' => 40) );
 		$value = get_option( $args['option'], $args['default'] );
 		printf( '<textarea rows="%s" cols="%s" name="%s" class="widefat">%s</textarea>', intval($args['rows']), intval($args['cols']), esc_attr($args['option']), esc_textarea($value) );
+		if ( !empty($args['description']) ) {
+			printf( '<p class="description">%s</p>', $args['description'] );
+		}
+	}
+
+	public function display_page_select_field( $args ) {
+		if ( !isset($args['option']) ) {
+			return;
+		}
+		$args = wp_parse_args( $args, array('default' => 0, 'description' => '' ) );
+		$value = get_option( $args['option'], $args['default'] );
+		wp_dropdown_pages( array(
+			'selected' => $value,
+			'name' => $args[ 'option' ],
+			'show_option_none' => false,
+		));
 		if ( !empty($args['description']) ) {
 			printf( '<p class="description">%s</p>', $args['description'] );
 		}
@@ -360,6 +397,10 @@ class Admin_Page {
 			<code>[email]</code> &ndash; This is the user's email address.<br />
 			<code>[lists]</code> &ndash; This is a list of the lists the user opted to subscribe to.", 'mailgun-subscriptions' );
 		return $description;
+	}
+
+	public function get_account_management_page_description() {
+		return __( 'Select which Page of your site will be used to display the Account Management page', 'mailgun-subscriptions' );
 	}
 }
  

--- a/Mailgun_Subscriptions/Confirmation_Handler.php
+++ b/Mailgun_Subscriptions/Confirmation_Handler.php
@@ -98,6 +98,7 @@ class Confirmation_Handler {
 		$message = $this->get_welcome_message_template();
 		$message = str_replace( '[email]', $this->confirmation->get_address(), $message );
 		$message = str_replace( '[lists]', $this->get_formatted_lists(), $message );
+		$message = str_replace( '[link]', esc_url_raw( $this->get_account_management_url( $this->confirmation->get_address() ) ), $message );
 		return $message;
 	}
 
@@ -116,6 +117,11 @@ class Confirmation_Handler {
 			}
 		}
 		return apply_filters( 'mailgun_welcome_email_lists', implode("\n", $formatted), $requested_lists );
+	}
+
+	protected function get_account_management_url( $email_address ) {
+		$token_emailer = new Account_Management_Token_Email( $email_address );
+		return $token_emailer->get_token_link();
 	}
 
 	public function setup_page_data( $post ) {

--- a/Mailgun_Subscriptions/Plugin.php
+++ b/Mailgun_Subscriptions/Plugin.php
@@ -5,7 +5,7 @@ namespace Mailgun_Subscriptions;
 
 
 class Plugin {
-	const VERSION = '1.1';
+	const VERSION = '1.1.1';
 
 	/** @var Plugin */
 	private static $instance = NULL;

--- a/Mailgun_Subscriptions/Plugin.php
+++ b/Mailgun_Subscriptions/Plugin.php
@@ -5,7 +5,7 @@ namespace Mailgun_Subscriptions;
 
 
 class Plugin {
-	const VERSION = '1.0';
+	const VERSION = '1.1';
 
 	/** @var Plugin */
 	private static $instance = NULL;

--- a/Mailgun_Subscriptions/Shortcode_Handler.php
+++ b/Mailgun_Subscriptions/Shortcode_Handler.php
@@ -9,6 +9,7 @@ class Shortcode_Handler {
 		add_shortcode( 'mailgun_email', array( $this, 'email_shortcode' ) );
 		add_shortcode( 'mailgun_lists', array( $this, 'lists_shortcode' ) );
 		add_shortcode( 'mailgun_subscription_form', array( $this, 'form_shortcode' ) );
+		add_shortcode( Account_Management_Page::SHORTCODE, array( $this, 'account_management_shortcode' ) );
 	}
 
 	public function email_shortcode( $atts, $content = '', $tag = '' ) {
@@ -83,5 +84,10 @@ class Shortcode_Handler {
 		$lists = Plugin::instance()->get_lists('name');
 		$lists = wp_list_filter( $lists, array( 'hidden' => true ), 'NOT' );
 		return array_keys($lists);
+	}
+
+	public function account_management_shortcode( $atts, $content = '', $tag = '' ) {
+		$page = Plugin::instance()->account_management_page();
+		return $page->get_page_contents();
 	}
 } 

--- a/Mailgun_Subscriptions/Submission_Handler.php
+++ b/Mailgun_Subscriptions/Submission_Handler.php
@@ -185,8 +185,8 @@ class Submission_Handler {
 
 	protected function get_redirect_base_url() {
 		$url = $_SERVER['REQUEST_URI'];
-		foreach ( array('mailgun-message', 'mailgun-error', 'mailgun-action', 'ref') as $key ) {
-			$url = remove_query_arg('key', $url);
+		foreach ( array('mailgun-message', 'mailgun-error', 'mailgun-action', 'ref', 'list', 'nonce') as $key ) {
+			$url = remove_query_arg( $key, $url );
 		}
 		return $url;
 	}

--- a/Mailgun_Subscriptions/Subscription_Form.php
+++ b/Mailgun_Subscriptions/Subscription_Form.php
@@ -70,7 +70,7 @@ class Subscription_Form {
 				$message = __('You are already subscribed. Please contact us if you have trouble receiving messages.', 'mailgun-subscriptions');
 				break;
 			default:
-				$message = $code;
+				$message = '';
 				break;
 		}
 		$message = apply_filters( 'mailgun_message', $message, $code, 'widget' );

--- a/Mailgun_Subscriptions/Suppressions.php
+++ b/Mailgun_Subscriptions/Suppressions.php
@@ -1,0 +1,119 @@
+<?php
+
+
+namespace Mailgun_Subscriptions;
+
+
+class Suppressions {
+	const BOUNCES      = 'bounces';
+	const UNSUBSCRIBES = 'unsubscribes';
+	const COMPLAINTS   = 'complaints';
+
+	/**
+	 * @var self[] For efficiency, instances are stored and reusable
+	 */
+	private static $instances = array();
+
+	private $email_address = '';
+	private $api           = null;
+	private $suppressions  = array(
+		'bounces'      => array(),
+		'unsubscribes' => array(),
+		'complaints'   => array(),
+	);
+
+	public function __construct( $email_address ) {
+		$this->email_address = $email_address;
+		$this->api = Plugin::instance()->api();
+	}
+
+	public function has_bounces( $list ) {
+		return $this->has_suppressions( self::BOUNCES, $list );
+	}
+
+	public function has_unsubscribes( $list ) {
+		return $this->has_suppressions( self::UNSUBSCRIBES, $list );
+	}
+
+	public function has_complaints( $list ) {
+		return $this->has_suppressions( self::COMPLAINTS, $list );
+	}
+
+	public function clear_all( $list ) {
+		$this->clear_bounces( $list );
+		$this->clear_complaints( $list );
+		$this->clear_unsubscribes( $list );
+	}
+
+	public function clear_bounces( $list ) {
+		$this->clear_suppressions( self::BOUNCES, $list );
+	}
+
+	public function clear_unsubscribes( $list ) {
+		$this->clear_suppressions( self::UNSUBSCRIBES, $list );
+	}
+
+	public function clear_complaints( $list ) {
+		$this->clear_suppressions( self::COMPLAINTS, $list );
+	}
+
+	private function extract_domain( $list ) {
+		$parts = explode( '@', $list );
+		return end( $parts );
+	}
+
+	private function has_suppressions( $type, $list ) {
+		$suppressions = $this->get_suppressions( $type, $list );
+		return !empty( $suppressions );
+	}
+
+	private function clear_suppressions( $type, $list ) {
+		$domain = $this->extract_domain( $list );
+		$endpoint = $this->get_endpoint( $type, $domain );
+		$response = $this->api->delete( $endpoint );
+
+		if ( !$response || $response[ 'response' ][ 'code' ] != 200 ) {
+			return false;
+		}
+		unset( $this->suppressions[ $type ][ $domain ] );
+		return true;
+	}
+
+	private function get_suppressions( $type, $list ) {
+		$domain = $this->extract_domain( $list );
+		if ( !isset( $this->suppressions[ $type ][ $domain ] ) ) {
+			$this->suppressions[ $type ][ $domain ] = $this->fetch_from_api( $type, $domain );
+		}
+		return $this->suppressions[ $type ][ $domain ];
+	}
+
+	private function fetch_from_api( $type, $domain ) {
+		$endpoint = $this->get_endpoint( $type, $domain );
+		$response = $this->api->get( $endpoint );
+
+		if ( !$response || $response[ 'response' ][ 'code' ] != 200 ) {
+			return false;
+		}
+
+		return $response[ 'body' ];
+	}
+
+	private function get_endpoint( $type, $domain ) {
+		return sprintf( '%s/%s/%s', $domain, $type, $this->email_address );
+	}
+
+	/**
+	 * Get an instance of this class for the given email address.
+	 * Works just like the constructor, but returns previously
+	 * used instances when possible to avoid extra API calls.
+	 * 
+	 * @param string $email_address
+	 * @return self
+	 */
+	public static function instance( $email_address ) {
+		if ( !isset( self::$instances[ $email_address ] ) ) {
+			self::$instances[ $email_address ] = new self( $email_address );
+		}
+		return self::$instances[ $email_address ];
+	}
+}

--- a/Mailgun_Subscriptions/Template.php
+++ b/Mailgun_Subscriptions/Template.php
@@ -10,10 +10,14 @@ abstract class Template {
 	}
 
 	public static function welcome_email() {
-		return __("Your email address, [email], has been confirmed. You are now subscribed to the following lists:\n\n[lists]", 'mailgun-subscriptions');
+		return __("Your email address, [email], has been confirmed. You are now subscribed to the following lists:\n\n[lists]\n\nTo manage your subscriptions, visit:\n\n[link]", 'mailgun-subscriptions');
 	}
 
 	public static function confirmation_page() {
 		return __("<p>Thank you for confirming your subscription. <strong>[mailgun_email]</strong> is now subscribed to:</p>[mailgun_lists]", 'mailgun-subscriptions');
+	}
+
+	public static function token_email() {
+		return __( "To manage your subscriptions, visit:\n\n[link]", 'mailgun-subscriptions' );
 	}
 }

--- a/Mailgun_Subscriptions/Widget.php
+++ b/Mailgun_Subscriptions/Widget.php
@@ -38,6 +38,14 @@ class Widget extends \WP_Widget {
 			'lists' => $instance['lists'],
 		));
 
+		if ( apply_filters( 'mailgun_subscriptions_widget_show_account_link', true ) ) {
+			$account_management_page = Plugin::instance()->account_management_page();
+			$link = $account_management_page->get_page_url();
+			if ( $link ) {
+				printf( '<p><a href="%s">%s</a></p>', esc_url( $link ), __( 'Manage your subscriptions', 'mailgun-subscriptions' ) );
+			}
+		}
+
 		echo $args['after_widget'];
 	}
 

--- a/assets/mailgun-subscriptions.css
+++ b/assets/mailgun-subscriptions.css
@@ -31,22 +31,24 @@
 }
 .mailgun-subscription-account-management .mailgun-subscription-details p {
 	margin: 0;
-	padding-left: 1.5em;
+	padding-left: 1em;
 }
 .mailgun-subscription-account-management .mailgun-subscription-details p.current-status {
 	padding-left: 0;
 }
 .mailgun-subscription-account-management .mailgun-subscription-details p.current-status::before {
 	display: inline-block;
-	width: 1em;
-	font-size: 1.5em;
-	line-height: 1;
+	width: .8em;
+	font-size: 1.25em;
+	line-height: 1.2;
+	position: relative;
+	top: 1px;
 }
 .mailgun-subscription-account-management .mailgun-subscription-details p.subscribe.current-status::before {
-	content: '\2611'; /* box with check */
+	content: '\2713'; /* check mark */
 	color: #23b225;
 }
 .mailgun-subscription-account-management .mailgun-subscription-details p.unsubscribe.current-status::before {
-	content: '\2612'; /* box with x */
+	content: '\2717'; /* box with x */
 	color: #d42626;
 }

--- a/assets/mailgun-subscriptions.css
+++ b/assets/mailgun-subscriptions.css
@@ -22,3 +22,31 @@
 .mailgun-message.error {
 	color: #CC0000;
 }
+
+.mailgun-subscription-account-management .mailgun-subscription-details {
+	margin: 0 0 1em;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details h3 {
+	margin: 0 0 0.25em;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details p {
+	margin: 0;
+	padding-left: 1.5em;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details p.current-status {
+	padding-left: 0;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details p.current-status::before {
+	display: inline-block;
+	width: 1em;
+	font-size: 1.5em;
+	line-height: 1;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details p.subscribe.current-status::before {
+	content: '\2611'; /* box with check */
+	color: #23b225;
+}
+.mailgun-subscription-account-management .mailgun-subscription-details p.unsubscribe.current-status::before {
+	content: '\2612'; /* box with x */
+	color: #d42626;
+}

--- a/mailgun-subscriptions.php
+++ b/mailgun-subscriptions.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/flightless/mailgun-subscriptions
 Description: A widget for visitors to subscribe to Mailgun mailing lists
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 1.0
+Version: 1.1
 Text Domain: mailgun-subscriptions
 Domain Path: /languages
 */

--- a/mailgun-subscriptions.php
+++ b/mailgun-subscriptions.php
@@ -5,7 +5,7 @@ Plugin URI: https://github.com/flightless/mailgun-subscriptions
 Description: A widget for visitors to subscribe to Mailgun mailing lists
 Author: Flightless
 Author URI: http://flightless.us/
-Version: 1.1
+Version: 1.1.1
 Text Domain: mailgun-subscriptions
 Domain Path: /languages
 */

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,8 @@ Install and activate just as a normal WordPress plugin.
 
 You'll find the "Mailgun Lists" settings page in the Settings admin menu. Here, you can setup your API keys, control which lists you're making available, and create custom descriptions for your lists.
 
+When the plugin is activated, the "Subscription Management" page will be automatically created for you. You can customize the title of this page, or set it to a different page using the option on the settings screen. If you accidentally delete the page, a new one will be created for you.
+
 ## Subscription Form Widget
 
 The plugin creates a widget called "Mailgun List Subscription Form". It includes options to set the title, an optional description, and the mailing lists that will be available in the widget.
@@ -35,7 +37,7 @@ The plugin creates a shortcode: `[mailgun_subscription_form]`. This displays the
 
 ### Confirmation Email
 
-You can set up templates for two emails the plugin will send.
+You can set up templates for three emails the plugin will send.
 
 When a user first submits the subscription form, the "Confirmation Email" is sent. Your template should contain the following shortcodes:
 
@@ -57,6 +59,7 @@ After the user confirms, the "Welcome Email" is sent. This template can include:
 
 * `[email]` - This is the user's email address.
 * `[lists]` - This is a list of the lists the user opted to subscribe to.
+* `[link]`  - This is the unique URL to the user's account management page.
 
 #### Filters
 
@@ -65,6 +68,18 @@ After the user confirms, the "Welcome Email" is sent. This template can include:
 `mailgun_welcome_email_template` - Edit the welcome email template.
 
 `mailgun_welcome_email_lists` - Edit the list of mailing lists in the email template.
+
+### Account Management Email
+
+When a user requests access to the account management page, they will receive this email. This template can include:
+
+* `[link]`  - This is the unique URL to the user's account management page.
+
+#### Filters
+
+`mailgun_token_email_subject` - Edit the subject of the welcome email.
+
+`mailgun_token_email_template` - Edit the account management email template.
 
 ## Confirmation Page
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: jbrinley
 Tags: mailing lists, subscriptions, widget, email
 Requires at least: 3.9
 Tested up to: 3.9
-Stable tag: 1.0
+Stable tag: 1.1
 License: BSD 3-Clause
 License URI: http://opensource.org/licenses/BSD-3-Clause
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: jbrinley
 Tags: mailing lists, subscriptions, widget, email
 Requires at least: 3.9
-Tested up to: 3.9
-Stable tag: 1.1
+Tested up to: 4.6
+Stable tag: 1.1.1
 License: BSD 3-Clause
 License URI: http://opensource.org/licenses/BSD-3-Clause
 
@@ -19,6 +19,10 @@ Add a Mailgun subscription form to your WordPress site. Your visitors can use th
 1. You'll find the "Mailgun Lists" settings page in the Settings admin menu. Here, you can setup your API keys, control which lists you're making available, and create custom descriptions for your lists.
 
 == Changelog ==
+
+= 1.1 =
+
+* New feature: subscription management
 
 = 1.0 =
 * Initial version


### PR DESCRIPTION
Adds an account management page where a user can see his current
subscription status and re/un/subscribe to lists.

Access is controlled via a cryptographic hash, which the user
can request by email.